### PR TITLE
Corrige el nombre del paquete en la instalación

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Este servicio permite consultar recorridos entre dos puntos dentro de la Ciudad de Buenos Aires,
 ya sea en transporte publico o en bicicleta.
-#Instalación
+
+# Instalación
 
 ```
-npm install @gcba-usig/recorridos
+npm install @usig-gcba/recorridos
 ```
 
 # Cómo usarlo


### PR DESCRIPTION
Reemplaza "@gcba-usig" por "@usig-gcba".